### PR TITLE
Fix: Prevent Disposing of Externally Provided Controllers in InteractiveSlider

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -81,7 +81,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/lib/interactive_slider.dart
+++ b/lib/interactive_slider.dart
@@ -195,12 +195,13 @@ class _InteractiveSliderState extends State<InteractiveSlider> {
   late final _height = ValueNotifier(widget.unfocusedHeight);
   late final _opacity = ValueNotifier(widget.unfocusedOpacity);
   late final _margin = ValueNotifier(widget.unfocusedMargin);
-  late final _progress =
-      widget.controller ?? ValueNotifier(widget.initialProgress);
+  late final _defaultProgress = ValueNotifier(widget.initialProgress);
   final _startIconKey = GlobalKey();
   final _endIconKey = GlobalKey();
   late ElasticOutCurve _transitionCurve;
   late double _maxSizeFactor;
+
+  ValueNotifier<double> get _progress => widget.controller ?? _defaultProgress;
 
   List<Widget> get _iconChildren {
     return [
@@ -242,6 +243,14 @@ class _InteractiveSliderState extends State<InteractiveSlider> {
 
   @override
   void didUpdateWidget(InteractiveSlider oldWidget) {
+    if (widget.controller != oldWidget.controller) {
+      if (oldWidget.controller != null) {
+        oldWidget.controller!.removeListener(_onChanged);
+      }
+      if (widget.controller != null) {
+        widget.controller!.addListener(_onChanged);
+      }
+    }
     super.didUpdateWidget(oldWidget);
     _updateCurveInfo();
   }
@@ -250,7 +259,7 @@ class _InteractiveSliderState extends State<InteractiveSlider> {
   void dispose() {
     _height.dispose();
     _opacity.dispose();
-    _progress.dispose();
+    _defaultProgress.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
### Overview

This pull request addresses a critical issue in the InteractiveSlider widget where externally provided controllers were being inadvertently disposed of by the widget. Disposing of external controllers can lead to unexpected behavior.

### Problem

In the existing implementation of the InteractiveSlider, the _progress controller is assigned either an externally provided widget.controller or a newly created internal ValueNotifier. However, the dispose method indiscriminately disposes of _progress regardless of its origin. This behavior causes runtime errors when an external InteractiveSliderController is provided, as disposing of a controller that is managed externally can lead to application crashes or unexpected behavior.

### Solution

Modified the InteractiveSlider widget to ensure that only internally created controllers are disposed of. If an external InteractiveSliderController is provided via the controller parameter, the widget will no longer dispose of it. This prevents accidental disposal and maintains the integrity of externally managed controllers.